### PR TITLE
MoodEventController update

### DIFF
--- a/code/app/src/main/java/com/otmj/otmjapp/Models/Entity.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Models/Entity.java
@@ -10,13 +10,22 @@ import java.util.Map;
  */
 public abstract class Entity implements Serializable {
     /**
-     * Converts a string map of values to a class.
+     * Converts a string map of values to a object.
      * @param map   Map containing (string, object) pairs which would coincide
      *              with the object's properties.
      * @return      Object that is formed from matching its properties with the
      *              values provided in the map
      */
      public static Entity fromMap(Map<String, Object> map) {
-         throw new UnsupportedOperationException("Not implemented yet");
+         throw new UnsupportedOperationException("Only call this method on subclasses of Entity!");
+     }
+
+    /**
+     * Converts an object to string map of its values.
+     * @return  Map containing (string, object) pairs which would coincide
+     *          with the object's properties.
+     */
+    public Map<String, Object> toMap() {
+         throw new UnsupportedOperationException("Only call this method on subclasses of Entity!");
      }
 }

--- a/code/app/src/main/java/com/otmj/otmjapp/Models/MoodEvent.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Models/MoodEvent.java
@@ -1,14 +1,22 @@
 package com.otmj.otmjapp.Models;
 
-import android.graphics.Bitmap;
 import android.location.Location;
 
+import com.google.firebase.firestore.ServerTimestamp;
+
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class MoodEvent extends Entity {
     private final String userID;
-    private final Date createdDate;
+    /**
+     * ServerTimestamp annotation automatically grabs the date and time
+     * the model was added to the database
+     */
+    @ServerTimestamp
+    private Date createdDate;
     private EmotionalState emotionalState;
     private String trigger;
     private SocialSituation socialSituation;
@@ -17,7 +25,6 @@ public class MoodEvent extends Entity {
     private String imageLink;
 
     public MoodEvent(String userID,
-                     Date createdDate,
                      int emotionColor,
                      String trigger,
                      String socialSituation,
@@ -25,7 +32,6 @@ public class MoodEvent extends Entity {
                      String reason,
                      String imageLink) {
         this.userID = userID;
-        this.createdDate = createdDate;
         this.emotionalState = EmotionalState.fromColor(emotionColor);
         this.trigger = trigger;
         this.socialSituation = SocialSituation.fromText(socialSituation);
@@ -102,8 +108,8 @@ public class MoodEvent extends Entity {
         this.reason = reason;
     }
 
-    public Bitmap getPhoto() {
-        throw new UnsupportedOperationException("Not yet implemented");
+    public String getImageLink() {
+        return imageLink;
     }
 
     public void setImageLink(String link) {
@@ -116,16 +122,33 @@ public class MoodEvent extends Entity {
      * @see Entity#fromMap(Map)
      */
     public static MoodEvent fromMap(Map<String, Object> map) {
-        // TODO: Fix emotional state and social situation
         return new MoodEvent(
                 (String) map.get("userID"),
                 (Date) map.get("createdDate"),
-                (EmotionalState) map.get("emotionalState"),
+                EmotionalState.fromColor((int) Objects.requireNonNull(map.get("emotionalState"))),
                 (String) map.get("trigger"),
-                (SocialSituation) map.get("socialSituation"),
-                (Location) map.getOrDefault("location", null),
+                SocialSituation.fromText((String) map.get("socialSituation")),
+                (Location) map.get("location"),
                 (String) map.get("reason"),
-                (String) map.getOrDefault("imageLink", "")
+                (String) map.get("imageLink")
         );
+    }
+
+    /**
+     * Custom implementation for storing MoodEvent in database.
+     * This static method creates a map from a MoodEvent.
+     * @see Entity#toMap()
+     */
+    public Map<String, Object> toMap() {
+       return Map.of(
+               "userID", userID,
+               "createdDate", createdDate,
+               "emotionalState", emotionalState.color, // Store enum with only its color
+               "trigger", trigger,
+               "socialSituation", socialSituation.toString(), // Store enum with its string
+               "location", location,
+               "reason", reason,
+               "imageLink", imageLink
+       );
     }
 }


### PR DESCRIPTION
- [x] Added `ServerTimestamp` annotation to created date to automatically retrieve date it was added to database
- [x] Changed name from `MoodHistoryController` to `MoodEventController`
- [x] Implemented add mood event functionality
- [x] Updated `Entity` and `MoodEvent` to include `toMap` method
- [x] In `FirestoreDB`, added functionality to use `toMap` method, or fallback to original implementation
- [x] Put down base for downloading image from database