### PR TITLE
Added 'Public' option to fragment for adding/editing fragment

### DIFF
--- a/code/app/src/main/java/com/otmj/otmjapp/Models/MoodEvent.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Models/MoodEvent.java
@@ -62,13 +62,15 @@ public class MoodEvent extends DatabaseObject {
                      SocialSituation socialSituation,
                      boolean includeLocation,
                      String reason,
-                     String imageLink) {
+                     String imageLink,
+                     MoodEvent.Privacy privacy) {
         this.userID = userID;
         setEmotionalState(emotionalState);
         this.trigger = trigger;
         setSocialSituation(socialSituation);
         this.reason = reason;
         this.imageLink = imageLink;
+        this.privacy = privacy;
 
 //        if (includeLocation) {
 //            // TODO: Get device's location
@@ -86,7 +88,8 @@ public class MoodEvent extends DatabaseObject {
                      String socialSituation,
                      boolean includeLocation,
                      String reason,
-                     String imageLink) {
+                     String imageLink,
+                     MoodEvent.Privacy privacy) {
         this(
                 userID,
                 EmotionalState.fromString(emotionalState),
@@ -94,7 +97,8 @@ public class MoodEvent extends DatabaseObject {
                 SocialSituation.fromText(socialSituation),
                 includeLocation,
                 reason,
-                imageLink
+                imageLink,
+                privacy
         );
     }
 

--- a/code/app/src/main/res/layout/create_mood_event.xml
+++ b/code/app/src/main/res/layout/create_mood_event.xml
@@ -320,6 +320,12 @@
 
     </com.google.android.material.chip.ChipGroup>
 
+    <Switch
+        android:id="@+id/privacy_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="   Make Public" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="80dp"


### PR DESCRIPTION
This option was implemented as a switch (I've attached a screenshot for reference). This can be changed later, I just needed something to work with for testing functionality.


![Screenshot 2025-03-13 172325](https://github.com/user-attachments/assets/0b480a77-ce35-407c-b0c3-a9bfc3f2c671)