### PR TITLE
Updated functionality to use MoodHistoryFilter instead of manual data parsing in getMoodEvents()

### DIFF
--- a/code/app/src/main/java/com/otmj/otmjapp/Fragments/TimelineFragment.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Fragments/TimelineFragment.java
@@ -1,7 +1,6 @@
 package com.otmj.otmjapp.Fragments;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -9,18 +8,14 @@ import android.widget.ListView;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.Observer;
 import androidx.navigation.fragment.NavHostFragment;
 
-import com.google.firebase.firestore.Filter;
 import com.otmj.otmjapp.Adapters.TimelineMoodEventAdapter;
-import com.otmj.otmjapp.Helper.FirestoreDB;
 import com.otmj.otmjapp.Helper.FollowHandler;
 import com.otmj.otmjapp.Helper.MoodEventsManager;
 import com.otmj.otmjapp.Helper.UserManager;
 import com.otmj.otmjapp.Models.MoodEvent;
 import com.otmj.otmjapp.Models.User;
-import com.otmj.otmjapp.R;
 import com.otmj.otmjapp.databinding.FragmentTimelineBinding;
 
 import java.util.ArrayList;
@@ -78,7 +73,7 @@ public class TimelineFragment extends Fragment {
             ids.add(currentUser.getID()); // Add user's ID to list
 
             MoodEventsManager moodEventsManager = new MoodEventsManager(ids);
-            moodEventsManager.getMoodEvents().observe(getViewLifecycleOwner(), moodEvents -> {
+            moodEventsManager.getPublicMoodEvents(null).observe(getViewLifecycleOwner(), moodEvents -> {
                 allMoodEvents.clear();
                 allMoodEvents.addAll(moodEvents);
 

--- a/code/app/src/main/java/com/otmj/otmjapp/Fragments/UserProfileFragment.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Fragments/UserProfileFragment.java
@@ -18,9 +18,12 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;
 import androidx.navigation.Navigation;
 
+import com.google.firebase.firestore.Filter;
 import com.otmj.otmjapp.Adapters.UserProfilePageMoodEventAdapter;
+import com.otmj.otmjapp.Helper.DBSortOption;
 import com.otmj.otmjapp.Helper.MoodEventsManager;
 import com.otmj.otmjapp.Helper.FollowHandler;
+import com.otmj.otmjapp.Helper.MoodHistoryFilter;
 import com.otmj.otmjapp.Helper.UserManager;
 import com.otmj.otmjapp.Models.MoodEvent;
 import com.otmj.otmjapp.Models.User;
@@ -71,32 +74,19 @@ public class UserProfileFragment extends Fragment {
             Navigation.findNavController(v).navigate(R.id.action_userProfileFragment_to_followersListFragment, args);
         });
 
-
         // Get UserID
         UserManager user_manager = UserManager.getInstance();
         User user = user_manager.getCurrentUser();
 
-        // Dummy data
-        //User user = new User("Kai", "kaiiscool@example.com", "123456", "https://exampleImageLink");
-        //Bitmap bitmapProfileImage = BitmapFactory.decodeResource(getResources(), R.drawable.dummy_profile_image);
-        //int numFollowers = 5;
-        //int numFollowing = 10;
-        //Timestamp temp_now = new Timestamp(new Date());
-        //MoodEvent moodEvent_3 = new MoodEvent(user.getID(),R.color.anger, "not happy", "Alone", false, "life is hard", null);
-        //MoodEvent moodEvent_1 = new MoodEvent(user.getID(), temp_now, EmotionalState.Anger, "not happy", SocialSituation.Alone, null, "live is hard",null);
-        //MoodEvent moodEvent_2 = new MoodEvent(user.getID(), temp_now, EmotionalState.Fear, "not happy", SocialSituation.With_1_Other, null, "live is hard",null);
-        //ArrayList<MoodEvent> temp_moodEvents = new ArrayList<MoodEvent>();
-        //temp_moodEvents.add(moodEvent_1);
-        //temp_moodEvents.add(moodEvent_2);
-
         // get MoodEvents
         MoodEventsManager mood_event_controller = new MoodEventsManager(List.of(user.getID()));
 
-        // add dummy data
-        //mood_event_controller.addMoodEvent(moodEvent_1);
-        //mood_event_controller.addMoodEvent(moodEvent_2);
+        // create filter to get only the moodEvents of the user that is signed in
+        DBSortOption sortOption = new DBSortOption("createdDate", true);
+        MoodHistoryFilter historyFilter = new MoodHistoryFilter(Filter.equalTo("userID", user.getID()),
+                                          sortOption);
 
-        moodEventsLiveData = mood_event_controller.getMoodEvents();
+        moodEventsLiveData = mood_event_controller.getUserMoodEvents(historyFilter);
         if (moodEventsLiveData != null) {
             getMoodEventFromDB();
         }


### PR DESCRIPTION
The only thing left to do now is handle the case where the user doesn't have any MoodEvents that they've posted or that their follows have posted since it causes the app to crash because of a null pointer exception.