### PR TITLE
Implemented functionality to go to list of follow requests from profile page

### DIFF
--- a/code/app/src/main/java/com/otmj/otmjapp/Adapters/RequestsListViewAdapter.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Adapters/RequestsListViewAdapter.java
@@ -1,0 +1,67 @@
+package com.otmj.otmjapp.Adapters;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.otmj.otmjapp.Helper.CircleTransform;
+import com.otmj.otmjapp.Models.User;
+import com.otmj.otmjapp.R;
+import com.squareup.picasso.Picasso;
+
+import java.util.ArrayList;
+
+public class RequestsListViewAdapter extends ArrayAdapter<User> {
+    public RequestsListViewAdapter(Context context, ArrayList<User> followersList) {
+        super(context, 0, followersList); // Pass context, layout resource, and the data
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        // If the list is empty, return an empty view
+        if (getCount() == 0) {
+            // You can choose to return a placeholder view here if necessary.
+            return new View(getContext()); // Empty view if the list is empty
+        }
+
+        View listItemView = convertView;
+
+        if(null == listItemView) {
+            listItemView = LayoutInflater.from(getContext()).inflate(R.layout.request_block, parent, false);
+        }
+
+        User user = getItem(position);
+        assert user != null;
+
+        // Set the username
+        TextView userNameTextView = listItemView.findViewById(R.id.username);
+        userNameTextView.setText(user.getUsername());
+
+        // Get the profile picture URL
+        String profilePicUrl = user.getProfilePictureLink();
+
+        // Check if the profile picture URL is null or empty
+        if (profilePicUrl == null || profilePicUrl.isEmpty()) {
+            profilePicUrl = "android.resource://com.otmj.otmjapp/drawable/placeholder_image"; // Use a placeholder image
+        }
+
+        // Set the profile picture using Picasso (with a placeholder)
+        ImageView profileImageView = listItemView.findViewById(R.id.profile_image);
+        Picasso.get()
+                .load(profilePicUrl)
+                .placeholder(R.drawable.profile_placeholder) // Placeholder while loading
+                .error(R.drawable.profile_placeholder) // Placeholder in case of an error
+                .transform(new CircleTransform()) // Apply the circular transformation
+                .into(profileImageView);
+
+        return listItemView;
+    }
+}

--- a/code/app/src/main/java/com/otmj/otmjapp/Adapters/TimelineMoodEventAdapter.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Adapters/TimelineMoodEventAdapter.java
@@ -5,7 +5,6 @@ import android.graphics.drawable.Drawable;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.format.DateUtils;
-import android.text.style.DynamicDrawableSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.ImageSpan;
 import android.view.LayoutInflater;
@@ -44,32 +43,34 @@ public class TimelineMoodEventAdapter extends ArrayAdapter<MoodEvent> {
         MoodEvent m = getItem(position);
         assert m != null;
 
-        TextView usernameText = view.findViewById(R.id.timeline_mood_event_username);
-        setMoodEventHeaderText(usernameText, m);
+        if(null != m.getUser()) {
+            TextView usernameText = view.findViewById(R.id.timeline_mood_event_username);
+            setMoodEventHeaderText(usernameText, m);
 
-        TextView description = view.findViewById(R.id.timeline_mood_event_desc);
-        if (m.getReason() != null && !m.getReason().isEmpty()) {
-            description.setText(m.getReason());
-        } else {
-            description.setVisibility(View.GONE);
-        }
+            TextView description = view.findViewById(R.id.timeline_mood_event_desc);
+            if (m.getReason() != null && !m.getReason().isEmpty()) {
+                description.setText(m.getReason());
+            } else {
+                description.setVisibility(View.GONE);
+            }
 
-        long createdTimeMillis = m.getCreatedDate() != null ? m.getCreatedDate().getTime() : System.currentTimeMillis();
-        String timeAgo = getTimeAgo(createdTimeMillis);
+            long createdTimeMillis = m.getCreatedDate() != null ? m.getCreatedDate().getTime() : System.currentTimeMillis();
+            String timeAgo = getTimeAgo(createdTimeMillis);
 
-        TextView timeAgoText = view.findViewById(R.id.timeline_mood_event_date);
-        timeAgoText.setText(timeAgo);
+            TextView timeAgoText = view.findViewById(R.id.timeline_mood_event_date);
+            timeAgoText.setText(timeAgo);
 
-        ImageView moodEventImage = view.findViewById(R.id.mood_image);
-        if (m.getImageLink() == null) {
-            moodEventImage.setVisibility(View.GONE);
-        }
+            ImageView moodEventImage = view.findViewById(R.id.mood_image);
+            if (m.getImageLink() == null) {
+                moodEventImage.setVisibility(View.GONE);
+            }
 
-        // TODO: Set location
-        // do not show for now
-        TextView locationText = view.findViewById(R.id.timeline_mood_event_location);
-        if (m.getLocation() == null) {
-            locationText.setVisibility(View.GONE);
+            // TODO: Set location
+            // do not show for now
+            TextView locationText = view.findViewById(R.id.timeline_mood_event_location);
+            if (m.getLocation() == null) {
+                locationText.setVisibility(View.GONE);
+            }
         }
 
 

--- a/code/app/src/main/java/com/otmj/otmjapp/Fragments/FollowListFragment.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Fragments/FollowListFragment.java
@@ -1,16 +1,17 @@
 package com.otmj.otmjapp.Fragments;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.util.Log;
 
 import androidx.fragment.app.Fragment;
 
 import com.otmj.otmjapp.Adapters.FollowersListViewAdapter;
+import com.otmj.otmjapp.Adapters.RequestsListViewAdapter;
 import com.otmj.otmjapp.Helper.FollowHandler;
 import com.otmj.otmjapp.Helper.UserManager;
 import com.otmj.otmjapp.Models.User;
@@ -19,16 +20,16 @@ import com.otmj.otmjapp.R;
 import java.util.ArrayList;
 
 /**
- * Displays a list of the user's followers.
+ * Displays a list of a user's follow requests, followers, or following users.
  */
-public class FollowersListFragment extends Fragment {
+public class FollowListFragment extends Fragment {
 
     private final FollowHandler followHandler;
 
     /**
      * Initializes the {@link FollowHandler} instance.
      */
-    public FollowersListFragment() {
+    public FollowListFragment() {
         followHandler = new FollowHandler();  // Initialize the FollowHandler
     }
 
@@ -37,6 +38,10 @@ public class FollowersListFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.list_screen, container, false);
+
+        // Get current user
+        UserManager userManager = UserManager.getInstance();
+        String currentUserId = userManager.getCurrentUser().getID();
 
         // Find the TextView for the list title
         TextView listTitle = rootView.findViewById(R.id.list_title);
@@ -51,18 +56,14 @@ public class FollowersListFragment extends Fragment {
                 listTitle.setText("FOLLOWERS");  // Set title for followers
 
                 // Log the button click event for followers
-                Log.d("FollowersListFragment", "Followers button clicked");
-
-                // Get the current user ID
-                UserManager userManager = UserManager.getInstance();
-                String currentUserId = userManager.getCurrentUser().getID();  // Get current user ID
+                Log.d("FollowListFragment", "Followers button clicked");
 
                 // Fetch followers using FollowHandler
                 followHandler.fetchFollowers(currentUserId, new FollowHandler.FollowCallback() {
                     @Override
                     public void onSuccess(ArrayList<User> followersList) {
                         // Log the followers list size
-                        Log.d("FollowersListFragment", "Followers List Size: " + (followersList != null ? followersList.size() : "null"));
+                        Log.d("FollowListFragment", "Followers List Size: " + (followersList != null ? followersList.size() : "null"));
 
                         // Once followers are fetched, pass them to the adapter
                         setUpFollowersList(rootView, followersList);
@@ -71,7 +72,7 @@ public class FollowersListFragment extends Fragment {
                     @Override
                     public void onFailure(Exception e) {
                         // Log the error if fetching fails
-                        Log.e("FollowersListFragment", "Error fetching followers", e);
+                        Log.e("FollowListFragment", "Error fetching followers", e);
                         // Optionally, show an error message
                     }
                 });
@@ -81,18 +82,14 @@ public class FollowersListFragment extends Fragment {
                 listTitle.setText("FOLLOWING");  // Set title for followers
 
                 // Log the button click event for following
-                Log.d("FollowersListFragment", "Following button clicked");
-
-                // Get the current user ID
-                UserManager userManager = UserManager.getInstance();
-                String currentUserId = userManager.getCurrentUser().getID();  // Get current user ID
+                Log.d("FollowListFragment", "Following button clicked");
 
                 // Fetch following using FollowHandler
                 followHandler.fetchFollowing(currentUserId, new FollowHandler.FollowCallback() {
                     @Override
                     public void onSuccess(ArrayList<User> followingList) {
                         // Log the following list size
-                        Log.d("FollowersListFragment", "Following List Size: " + (followingList != null ? followingList.size() : "null"));
+                        Log.d("FollowListFragment", "Following List Size: " + (followingList != null ? followingList.size() : "null"));
 
                         // Once following are fetched, pass them to the adapter
                         setUpFollowersList(rootView, followingList);
@@ -101,7 +98,7 @@ public class FollowersListFragment extends Fragment {
                     @Override
                     public void onFailure(Exception e) {
                         // Log the error if fetching fails
-                        Log.e("FollowersListFragment", "Error fetching following", e);
+                        Log.e("FollowListFragment", "Error fetching following", e);
                         // Optionally, show an error message
                     }
                 });
@@ -109,18 +106,14 @@ public class FollowersListFragment extends Fragment {
                 listTitle.setText("PEOPLE YOU MAY KNOW");  // Set title for followers
 
                 // Log the button click event for following
-                Log.d("FollowersListFragment", "peopleYouMayKnow button clicked");
-
-                // Get the current user ID
-                UserManager userManager = UserManager.getInstance();
-                String currentUserId = userManager.getCurrentUser().getID();  // Get current user ID
+                Log.d("FollowListFragment", "peopleYouMayKnow button clicked");
 
                 // Todo: Replace with people you may know queries
                 followHandler.fetchNotFollowingUsers(new FollowHandler.FollowCallback() {
                     @Override
                     public void onSuccess(ArrayList<User> notFollowingList) {
                         // Log the following list size
-                        Log.d("FollowersListFragment", "notFollowingList List Size: " + (notFollowingList != null ? notFollowingList.size() : "null"));
+                        Log.d("FollowListFragment", "notFollowingList List Size: " + (notFollowingList != null ? notFollowingList.size() : "null"));
 
                         // Once following are fetched, pass them to the adapter
                         setUpFollowersList(rootView, notFollowingList);
@@ -129,9 +122,21 @@ public class FollowersListFragment extends Fragment {
                     @Override
                     public void onFailure(Exception e) {
                         // Log the error if fetching fails
-                        Log.e("FollowersListFragment", "Error fetching following", e);
+                        Log.e("FollowListFragment", "Error fetching following", e);
                         // Optionally, show an error message
                     }
+                });
+            } else if("requests".equals(buttonClicked)) {
+                listTitle.setText("REQUESTS");  // Set title for followers
+
+                followHandler.getRequests(new FollowHandler.FollowCallback() {
+                    @Override
+                    public void onSuccess(ArrayList<User> requestsList) {
+                        setUpRequestsList(rootView, requestsList);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) { /*TODO: Handle failure*/ }
                 });
             }
         }
@@ -143,15 +148,23 @@ public class FollowersListFragment extends Fragment {
      * Sets up the {@link ListView} with the provided list of followers or users that the current user is following.
      *
      * @param rootView                 The root view of the fragment.
-     * @param followersorfollowingList The list of followers or users that the current user is following.
+     * @param followList The list of followers or users that the current user is following.
      */
     // Set up the ListView with the followers data
-    private void setUpFollowersList(View rootView, ArrayList<User> followersorfollowingList) {
+    private void setUpFollowersList(View rootView, ArrayList<User> followList) {
         ListView listView = rootView.findViewById(R.id.user_list_view);
 
         // Populate the list
-        FollowersListViewAdapter adapter = new FollowersListViewAdapter(getContext(), followersorfollowingList);
+        FollowersListViewAdapter adapter = new FollowersListViewAdapter(getContext(), followList);
         listView.setAdapter(adapter);
 
+    }
+
+    private void setUpRequestsList(View rootView, ArrayList<User> requestList) {
+        ListView listView = rootView.findViewById(R.id.user_list_view);
+
+        // Populate the list
+        RequestsListViewAdapter adapter = new RequestsListViewAdapter(getContext(), requestList);
+        listView.setAdapter(adapter);
     }
 }

--- a/code/app/src/main/java/com/otmj/otmjapp/Fragments/TimelineFragment.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Fragments/TimelineFragment.java
@@ -8,7 +8,6 @@ import android.widget.ListView;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.Observer;
 import androidx.navigation.Navigation;
 import androidx.navigation.fragment.NavHostFragment;
 
@@ -18,6 +17,7 @@ import com.otmj.otmjapp.Helper.MoodEventsManager;
 import com.otmj.otmjapp.Helper.UserManager;
 import com.otmj.otmjapp.Models.MoodEvent;
 import com.otmj.otmjapp.Models.User;
+import com.otmj.otmjapp.R;
 import com.otmj.otmjapp.databinding.FragmentTimelineBinding;
 
 import java.util.ArrayList;

--- a/code/app/src/main/java/com/otmj/otmjapp/Fragments/UserProfileFragment.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Fragments/UserProfileFragment.java
@@ -1,28 +1,21 @@
 package com.otmj.otmjapp.Fragments;
 
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.Observer;
 import androidx.navigation.Navigation;
 
 import com.google.firebase.firestore.Filter;
 import com.otmj.otmjapp.Adapters.UserProfilePageMoodEventAdapter;
 import com.otmj.otmjapp.Helper.DBSortOption;
-import com.otmj.otmjapp.Helper.MoodEventsManager;
 import com.otmj.otmjapp.Helper.FollowHandler;
+import com.otmj.otmjapp.Helper.MoodEventsManager;
 import com.otmj.otmjapp.Helper.MoodHistoryFilter;
 import com.otmj.otmjapp.Helper.UserManager;
 import com.otmj.otmjapp.Models.MoodEvent;
@@ -65,13 +58,22 @@ public class UserProfileFragment extends Fragment {
             Navigation.findNavController(v).navigate(R.id.action_userProfileFragment_to_followersListFragment, args);
         });
 
-        // Navigate to Followers List when Followers Button is clicked
+        // Navigate to Followers List when Following Button is clicked
         binding.followingButton.setOnClickListener(v -> {
             Bundle args = new Bundle();
             args.putString("buttonClicked", "following");  // Add an argument indicating which button was clicked
 
-            // Navigate to Followers List using Navigation Component
-            Navigation.findNavController(v).navigate(R.id.action_userProfileFragment_to_followersListFragment, args);
+            // Navigate to Following List using Navigation Component
+            Navigation.findNavController(v).navigate(R.id.action_userProfileFragment_to_followingListFragment, args);
+        });
+
+        // Navigate to Requests List when Requests Button is clicked
+        binding.requestsButton.setOnClickListener(v -> {
+            Bundle args = new Bundle();
+            args.putString("buttonClicked", "requests");  // Add an argument indicating which button was clicked
+
+            // Navigate to Requests List using Navigation Component
+            Navigation.findNavController(v).navigate(R.id.action_userProfileFragment_to_followingListFragment, args);
         });
 
         // Get UserID

--- a/code/app/src/main/java/com/otmj/otmjapp/Helper/MoodEventsManager.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Helper/MoodEventsManager.java
@@ -104,7 +104,11 @@ public class MoodEventsManager {
                             }
                         }
 
-                        moodHistory.setValue(moodEvents);
+                        if(moodEvents.isEmpty()) {
+                            moodHistory.setValue(new ArrayList<>());
+                        } else {
+                            moodHistory.setValue(moodEvents);
+                        }
                     }
 
                     @Override

--- a/code/app/src/main/java/com/otmj/otmjapp/Models/FollowRequest.java
+++ b/code/app/src/main/java/com/otmj/otmjapp/Models/FollowRequest.java
@@ -4,6 +4,11 @@ package com.otmj.otmjapp.Models;
  * Represents a follow request between two users.
  */
 public class FollowRequest extends Follow {
+    // Need an empty constructor for Firebase
+    FollowRequest() {
+        super("", "");
+    }
+
     public FollowRequest(String followerID, String followeeID){
         super(followerID, followeeID);
     }

--- a/code/app/src/main/res/navigation/app_nav_graph.xml
+++ b/code/app/src/main/res/navigation/app_nav_graph.xml
@@ -53,7 +53,7 @@
     <!-- Followers List Fragment -->
     <fragment
         android:id="@+id/followersListFragment"
-        android:name="com.otmj.otmjapp.Fragments.FollowersListFragment"
+        android:name="com.otmj.otmjapp.Fragments.FollowListFragment"
         android:label="fragment_followers_list"
         tools:layout="@layout/list_screen" />
 </navigation>


### PR DESCRIPTION
The page will also list any follow requests you have in the database. If you want to see what this looks like, you can go into the Firestore database and manually add records for the account that is signed in or you can sign in with my account.

The functionality for the 'Confirm' button is not implemented yet, but it can be completed in this week's sprint.